### PR TITLE
Updated format for kettle price dispay

### DIFF
--- a/Home.py
+++ b/Home.py
@@ -22,18 +22,17 @@ st.set_page_config(
     initial_sidebar_state="expanded",
 )
 
-plotMarkerColor = "#7DBDF5"  # plot marker colour
-
 config = load_config()
 colors = config["theme"]
 st.session_state.bg_color = colors["backgroundColor"]
 st.session_state.font = colors["textColor"]
-st.session_state.marker = plotMarkerColor
+st.session_state.marker = "#7DBDF5"
 st.session_state.textBoxColor = "#2A69A1"
 st.session_state.textColor = "#B5146A"
+st.session_state.primary_color = colors["primaryColor"]
 
 load_css()
-st.session_state.primary_color = colors["primaryColor"]
+
 
 if "api_key" not in st.session_state:
     st.session_state.api_key = ""  # Default value

--- a/agile_home_dashboard.py
+++ b/agile_home_dashboard.py
@@ -135,3 +135,5 @@ def load_css():
         """,
         unsafe_allow_html=True,
     )
+
+    st.session_state.col_format = f"background-color: {st.session_state.primary_color}; color: white; text-align: center; padding: 20px; border-radius: 10px; display: flex; align-items: center; justify-content: center; flex-direction: column;"

--- a/pages/Kettle_Pricing.py
+++ b/pages/Kettle_Pricing.py
@@ -17,10 +17,7 @@ def calculate_kettle_cost(current_price, next_price, run_time, power):
 def display_kettle_costs(
     current_price, next_price, cost_now, cost_next, current_cost_row, next_cost_row
 ):
-    (
-        col1,
-        col2,
-    ) = st.columns(2, gap="small")
+    col1, col2 = st.columns(2, gap="small")
     w = "95%"
     h = "120px"
     with col1:

--- a/pages/Kettle_Pricing.py
+++ b/pages/Kettle_Pricing.py
@@ -4,6 +4,8 @@ import streamlit as st
 
 from agile_home_dashboard import get_current_cost, get_current_time, load_css
 
+load_css()
+
 
 def calculate_kettle_cost(current_price, next_price, run_time, power):
     cost_now = ((run_time / 3600) * current_price * power) / 100
@@ -15,67 +17,74 @@ def calculate_kettle_cost(current_price, next_price, run_time, power):
 def display_kettle_costs(
     current_price, next_price, cost_now, cost_next, current_cost_row, next_cost_row
 ):
-    st.markdown(
-        f"""
-        <div style="text-align: center;">
-            <strong>Current Energy Cost</strong><br>
-            <span style="font-size: 1.5em; color: black;">{current_price:.4f} p/kWh</span>
-        </div>
-        """,
-        unsafe_allow_html=True,
-    )
-
-    # Next energy cost
-    st.markdown(
-        f"""
-        <div style="text-align: center; margin-top: 20px;">
-            <strong>Next Energy Cost</strong><br>
-            <span style="font-size: 1.5em; color: black;">{next_price:.4f} p/kWh</span>
-        </div>
-        """,
-        unsafe_allow_html=True,
-    )
-
-    # Kettle current cost
-    st.markdown(
-        """
-        <div style="text-align: center; margin-top: 30px;">
-            <strong>Kettle Current Cost</strong><br>
-            <span style="font-size: 1.2em; color: black;">£{:.4f}</span><br>
-            <small>Valid until {}</small>
-        </div>
-        """.format(cost_now, current_cost_row.iloc[0]["valid_to"].strftime("%H:%M")),
-        unsafe_allow_html=True,
-    )
-
-    # Kettle next cost with color coding
-    color = "green" if cost_next <= cost_now else "red"
-    if next_price == 0:
-        color = "black"
+    (
+        col1,
+        col2,
+    ) = st.columns(2, gap="small")
+    w = "95%"
+    h = "120px"
+    with col1:
         st.markdown(
             f"""
-        <div style="text-align: center; margin-top: 30px;">
-            <strong>Kettle Next Cost</strong><br>
-            <span style="font-size: 1.2em; color: {color};">£{cost_next:.4f}</span><br>
-            <small>The next kettle cost is not available</small>
+            <div style="display: flex; justify-content: center;">
+                <div style="{st.session_state.col_format};
+                    height: {h};
+                    width: {w};">
+                    <strong>Current Energy Cost</strong><br>
+                    <span style="font-size: 1.5em;">{current_price:.4f} p/kWh</span>
+                </div>
+            </div>
+            """,
+            unsafe_allow_html=True,
+        )
+
+    with col2:
+        st.markdown(
+            f"""
+        <div style="display: flex; justify-content: center;">
+            <div style="{st.session_state.col_format};
+            height: {h};
+            width: {w};">
+                <strong>Next Energy Cost</strong><br>
+                <span style="font-size: 1.5em;">{next_price:.4f} p/kWh</span>
+            </div>
         </div>
         """,
             unsafe_allow_html=True,
         )
-    else:
+
+    st.markdown("<div style='margin-bottom: 30px;'></div>", unsafe_allow_html=True)
+
+    col3, col4 = st.columns(2, gap="small")
+    with col3:
         st.markdown(
-            """
-            <div style="text-align: center; margin-top: 30px;">
-                <strong>Kettle Next Cost</strong><br>
-                <span style="font-size: 1.2em; color: {};">£{:.4f}</span><br>
-                <small>From {} to {}</small>
+            f"""
+            <div style="display: flex; justify-content: center;">
+                <div style="{st.session_state.col_format};
+                height: {h};
+                width: {w};">
+                    <strong>Current Kettle Cost</strong><br>
+                    <span style="font-size: 1.5em;">£{cost_now:.4f}</span>
+                    <span style="font-size: 1em;">Valid until {current_cost_row.iloc[0]["valid_to"].strftime("%H:%M")}</span>
+                </div>
             </div>
-            """.format(
-                color,
-                cost_next,
-                next_cost_row["valid_from"].strftime("%H:%M"),
-                next_cost_row["valid_to"].strftime("%H:%M"),
-            ),
+            """,
+            unsafe_allow_html=True,
+        )
+
+    with col4:
+        st.markdown(
+            f"""
+            <div style="display: flex; justify-content: center;">
+                <div style="{st.session_state.col_format};
+                height: {h};
+                width: {w};">
+                    <strong>Next Kettle Cost</strong><br>
+                    <span style="font-size: 1.5em;">£{cost_next:.4f}</span>
+                    <span style="font-size: 1em;">Valid from {next_cost_row["valid_from"].strftime("%H:%M")} to {next_cost_row["valid_to"].strftime("%H:%M")} </span>
+                </div>
+            </div>
+            """,
             unsafe_allow_html=True,
         )
 
@@ -124,20 +133,68 @@ def plot_kettle_timing():
     st.plotly_chart(fig)
 
 
-color = "#B87272"
-load_css()
+st.markdown(
+    """
+    <style>{
+        font-size: 1.5em;
+        font-weight: bold;
+    }
+
+    div[data-baseweb="input"] input {
+        font-size: 1.1em;
+        padding: 10px;
+        height: 60px;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+    }
+    </style>
+    """,
+    unsafe_allow_html=True,
+)
 
 
 def main():
     st.title("Kettle Pricing on Octopus Agile")
     if st.session_state.df is not None:
-        st.write("How much does the kettle cost right now?")
+        st.markdown(
+            f"""
+                <div style="
+                    color: {st.session_state.font};
+                    border-radius: 10px;
+                    margin-bottom: 10px;">
+                    <span style="font-size: 1.1em;">Kettle run time [s]:</span><br>
+                </div>
+                """,
+            unsafe_allow_html=True,
+        )
 
         run_time = st.number_input(
-            "Kettle run time [s]:", min_value=0, max_value=10000, value=137
+            "Kettle run time [s]:",
+            min_value=0,
+            max_value=10000,
+            value=137,
+            label_visibility="collapsed",
         )
+
+        st.markdown(
+            f"""
+                <div style="
+                    color: {st.session_state.font};
+                    border-radius: 10px;
+                    margin-bottom: 10px;">
+                    <span style="font-size: 1.1em;">Kettle power [kW]:</span><br>
+                </div>
+                """,
+            unsafe_allow_html=True,
+        )
+
         power = st.number_input(
-            "Kettle power [kW]:", min_value=0.0, max_value=1e8, value=2.1
+            "Kettle power [kW]:",
+            min_value=0.0,
+            max_value=1e8,
+            value=2.1,
+            label_visibility="collapsed",
         )
 
         # Toggle for manual time selection

--- a/pages/Oven_Pricing.py
+++ b/pages/Oven_Pricing.py
@@ -8,12 +8,10 @@ load_css()
 def display_oven_costs(current_price, next_price, cost_now, current_cost_row):
     col1, col2, col3 = st.columns(3)
 
-    col_format = f"background-color: {st.session_state.primary_color}; color: white; text-align: center; padding: 20px; border-radius: 10px;"
-
     with col1:
         st.markdown(
             f"""
-            <div style="{col_format}">
+            <div style="{st.session_state.col_format}">
                 <strong style="font-size: 1.2em;">Current Energy Cost</strong><br>
                 <span style="font-size: 1.4em;">{current_price:.4f} p/kWh</span>
             </div>
@@ -24,7 +22,7 @@ def display_oven_costs(current_price, next_price, cost_now, current_cost_row):
     with col2:
         st.markdown(
             f"""
-                <div style="{col_format}">
+                <div style="{st.session_state.col_format}">
                     <strong style="font-size: 1.2em;">Next Energy Cost</strong><br>
                     <span style="font-size: 1.4em;">{next_price:.4f} p/kWh</span>
                 </div>
@@ -35,7 +33,7 @@ def display_oven_costs(current_price, next_price, cost_now, current_cost_row):
     with col3:
         st.markdown(
             f"""
-                <div style="{col_format}">
+                <div style="{st.session_state.col_format}">
                     <strong style="font-size: 1.2em;">Total Oven Cost</strong><br>
                     <span style="font-size: 1.4em;">£{cost_now:.4f}</span>
                 </div>
@@ -44,16 +42,9 @@ def display_oven_costs(current_price, next_price, cost_now, current_cost_row):
         )
 
 
-def calculate_kettle_cost(current_price, next_price, run_time, power):
-    cost_now = ((run_time / 3600) * current_price * power) / 100
-    cost_next = ((run_time / 3600) * next_price * power) / 100
-    return cost_now, cost_next
-
-
 st.markdown(
     """
-    <style>
-    label[for="total-bake-time"] {
+    <style>{
         font-size: 1.5em;
         font-weight: bold;
     }
@@ -62,6 +53,9 @@ st.markdown(
         font-size: 1.1em;
         padding: 10px;
         height: 60px;
+        display: flex;
+        justify-content: center;
+        align-items: center;
     }
     </style>
     """,
@@ -81,12 +75,13 @@ def main():
                 <div style="
                     color: {st.session_state.font};
                     border-radius: 10px;
-                    padding-bottom: 10px;">
+                    margin-bottom: 10px;">
                     <span style="font-size: 1.1em;">Total bake time [min]:</span><br>
                 </div>
                 """,
             unsafe_allow_html=True,
         )
+
         bake_time = st.number_input(
             "Total bake time [min]: ", value=20, label_visibility="collapsed"
         )


### PR DESCRIPTION
Format updated to match oven pricing page. 
Column formatting moved to `load_css()` 

<img width="984" alt="image" src="https://github.com/user-attachments/assets/d50058a2-507d-4cee-b356-9fd81c54ba93" />
